### PR TITLE
feat: Add Fortran CI and update documentation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,9 +81,39 @@ jobs:
           name: doc
           path: doc/_build
 
+  test-fortran:
+    name: Test Fortran (0D)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y gfortran libnetcdff-dev cmake git
+      - uses: actions/checkout@v4
+      - name: Set up environment variables
+        run: |
+          echo "TAME_BASE=$GITHUB_WORKSPACE" >> $GITHUB_ENV
+          echo "FABM_BASE=$HOME/fabm" >> $GITHUB_ENV
+      - name: Clone FABM
+        run: git clone --depth 1 https://github.com/fabm-model/fabm.git $HOME/fabm
+      - name: Create build directory
+        run: mkdir $HOME/build_fabm_0d
+      - name: Configure fabm0d build
+        run: |
+          cmake -B $HOME/build_fabm_0d -S ${{ env.FABM_BASE }}/src/drivers/0d \
+          -DFABM_HOST=0d -DFABM_INSTITUTES=tame -DFABM_TAME_BASE=${{ env.TAME_BASE }}
+      - name: Build fabm0d
+        run: cmake --build $HOME/build_fabm_0d
+      - name: Copy fabm0d executable
+        run: cp $HOME/build_fabm_0d/fabm0d ${{ env.TAME_BASE }}/setup/0d/
+      - name: Change directory and execute 0D test
+        run: |
+          cd ${{ env.TAME_BASE }}/setup/0d/
+          ./fabm0d
+
   deploy-package:
     if: github.ref == 'refs/heads/main'
-    needs: [test-package, test-docs, test]
+    needs: [test-package, test-docs, test, test-fortran]
     runs-on: ubuntu-latest
     container: python:3.12
     steps:

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -5,6 +5,7 @@ SPDX-License-Identifier: CC0-1.0
 -->
 
 [![CI](https://codebase.helmholtz.cloud/kse/generalized-aquatic-ecosystem-model/badges/main/pipeline.svg)](https://codebase.helmholtz.cloud/kse/generalized-aquatic-ecosystem-model/-/pipelines?page=1&scope=all&ref=main)
+[![GitHub CI](https://github.com/YOUR_GITHUB_USERNAME_OR_ORG/YOUR_REPOSITORY_NAME/actions/workflows/ci.yaml/badge.svg)](https://github.com/YOUR_GITHUB_USERNAME_OR_ORG/YOUR_REPOSITORY_NAME/actions/workflows/ci.yaml)
 [![Code coverage](https://codebase.helmholtz.cloud/kse/generalized-aquatic-ecosystem-model/badges/main/coverage.svg)](https://codebase.helmholtz.cloud/kse/generalized-aquatic-ecosystem-model/-/graphs/main/charts)
 
 <!-- TODO: uncomment the following line when the package is registered at https://readthedocs.org -->
@@ -94,6 +95,8 @@ make
 ```
 
 For more information on the FABM `CMake` build, consult their [building and installing](https://github.com/fabm-model/fabm/wiki/Building-and-installing) page.
+
+The continuous integration setup on GitHub now includes automated checks for the Fortran components, ensuring they compile correctly and pass a basic runtime test using the 0D driver.
 
 Note that `-DFABM_INSTITUTES=tame` will make FABM compile our models as the _only_ available biogeochemical models. If you additionally want to have access to other biogeochemical models included with FABM, you can set `FABM_INSTITUTES` to a semi-colon separated list, e.g., `-DFABM_INSTITUTES="tame;vims;iow"`, as in the example above.
 


### PR DESCRIPTION
Adds a GitHub Actions workflow job to test the Fortran components:
- Compiles TAME as a FABM institute using the 0D driver.
- Runs a basic execution test using the 'setup/0d' scenario.
- Integrates this Fortran test into the existing CI structure, making it a requirement for package deployment.

Updates ReadMe.md to include:
- A placeholder badge for the GitHub Actions CI status.
- A note informing you about the new Fortran CI coverage.